### PR TITLE
Returns real root object rather than empty wrapper

### DIFF
--- a/src/cfg.c
+++ b/src/cfg.c
@@ -235,11 +235,13 @@ int nereon_parse_cfg_options(const char *cfg_fpath, struct nereon_cfg_options **
 	ucl_object_t *obj = NULL;
 
 	char *cfg_str;
-	struct nereon_cfg_options *root_opt = NULL;
+	struct nereon_cfg_options root_opt;
 
 	int ret = -1;
 
 	DEBUG_PRINT("Parsing configuration options\n");
+
+	memset(&root_opt, 0, sizeof(root_opt));
 
 	/* get configuration contents from file */
 	if (read_file_contents(cfg_fpath, &cfg_str) == 0) {
@@ -269,21 +271,16 @@ int nereon_parse_cfg_options(const char *cfg_fpath, struct nereon_cfg_options **
 	}
 
 	/* parse HCL options */
-	root_opt = new_cfg_option();
-	if (!root_opt)
-		goto end;
-
-	ret = parse_config_options(obj, root_opt);
+	ret = parse_config_options(obj, &root_opt);
 	if (ret == 0) {
-		*cfg_opts = root_opt;
+		*cfg_opts = root_opt.childs;
 
 #ifdef DEBUG
-		print_config_options(root_opt, 0);
+		print_config_options(root_opt.childs, 0);
 #endif
 	} else {
-		free_config_options(root_opt);
+		free_config_options(root_opt.childs);
 	}
-
 end:
 	/* free object and parser */
 	if (obj)


### PR DESCRIPTION
Hi @jjr840430 I hope this makes sense - currently the root of the config tree is always a void object with the real config in root->childs. This PR changes that so the root config is the real root from the config file.